### PR TITLE
[CMake] depend on example-robot-data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,48 +22,6 @@ INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/hpp.cmake)
 INCLUDE(cmake/hpp/python.cmake)
 
-FIND_PROGRAM(XACRO_EXECUTABLE xacro)
-
-# GENERATE_URDF_FILE FILENAME EXTENSION
-# ------------------------------------
-#
-# Generate urdf ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}.${EXTENSION}
-# from xacro ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}.xacro file.
-#
-# To trigger generation, use:
-# ADD_CUSTOM_TARGET (generate_urdf_files DEPENDS ${ALL_GENERATED_URDF})
-#
-# FILENAME : XACRO filename without the extension
-#
-# Note : If ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}.xacro does not exists,
-#        the macros tries to configure file ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}.xacro.in
-#
-MACRO(GENERATE_URDF_FILE FILENAME)
-  SET(_XACRO_FILE_ ${UR_DESCRIPTION_PREFIX}/share/ur_description/${FILENAME}.xacro)
-  IF (NOT EXISTS ${_XACRO_FILE_})
-    MESSAGE(FATAL_ERROR "cannot find \"${_XACRO_FILE_}\"")
-  ENDIF (NOT EXISTS ${_XACRO_FILE_})
-
-  ADD_CUSTOM_COMMAND(
-    OUTPUT ${FILENAME}
-    COMMAND ${XACRO_EXECUTABLE}
-    ARGS -o ${FILENAME} ${_XACRO_FILE_}
-    MAIN_DEPENDENCY ${_XACRO_FILE_}
-    COMMENT "Generating ${FILENAME} from ${_XACRO_FILE_}"
-    )
-  LIST(APPEND ALL_GENERATED_URDF ${FILENAME})
-
-  # Clean generated files.
-  SET_PROPERTY(
-    DIRECTORY APPEND PROPERTY
-    ADDITIONAL_MAKE_CLEAN_FILES
-    ${OUTPUT_FILE}
-    )
-
-  LIST(APPEND LOGGING_WATCHED_VARIABLES ALL_GENERATED_URDF)
-ENDMACRO(GENERATE_URDF_FILE FILENAME CONFIGURE)
-
-
 SET(PROJECT_NAME hpp-universal-robot)
 SET(PROJECT_DESCRIPTION
   "Data specific to ur5 and 10 robots for hpp-corbaserver")
@@ -72,25 +30,10 @@ SETUP_HPP_PROJECT()
 
 HPP_FINDPYTHON()
 
-ADD_REQUIRED_DEPENDENCY ("ur_description >= 1")
+ADD_REQUIRED_DEPENDENCY ("example-robot-data >= 2.2.0")
 
-# Generate urdf files from xacro files
-MAKE_DIRECTORY(urdf)
-SET(XACRO_FILES
-  urdf/ur5_joint_limited_robot.urdf
-  )
-FOREACH(it ${XACRO_FILES})
- GENERATE_URDF_FILE (${it})
-ENDFOREACH(it)
-ADD_CUSTOM_TARGET (generate_urdf_file ALL DEPENDS ${ALL_GENERATED_URDF})
 # Install files
-SET (UR_DESCRIPTION_DATAROOTDIR ${CMAKE_INSTALL_PREFIX}/share/ur_description)
-
-INSTALL(FILES
-  ${CMAKE_BINARY_DIR}/urdf/ur5_joint_limited_robot.urdf
-  DESTINATION ${UR_DESCRIPTION_DATAROOTDIR}/urdf
-  )
-
+SET (UR_DESCRIPTION_DATAROOTDIR ${CMAKE_INSTALL_PREFIX}/share/example-robot-data/ur_description)
 
 INSTALL(FILES
   ${PROJECT_SOURCE_DIR}/src/hpp/corbaserver/ur5/robot.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/hpp.cmake)
-INCLUDE(cmake/hpp/python.cmake)
+INCLUDE(cmake/python.cmake)
 
 SET(PROJECT_NAME hpp-universal-robot)
 SET(PROJECT_DESCRIPTION
@@ -28,7 +28,7 @@ SET(PROJECT_DESCRIPTION
 
 SETUP_HPP_PROJECT()
 
-HPP_FINDPYTHON()
+FINDPYTHON()
 
 ADD_REQUIRED_DEPENDENCY ("example-robot-data >= 2.2.0")
 


### PR DESCRIPTION
To avoid dependencies on xacro, and as ur-description is not packaged anymore by the ROS buildfarm, to avoid dependencies on universal-robot, which depends moveit, gazebo, bullet, opencv, etc.

While here, remove `HPP_FINDPYTHON`